### PR TITLE
GHC 9.2.8 Upgrade for ghc-hasfield-plugin

### DIFF
--- a/ghc-hasfield-plugin.cabal
+++ b/ghc-hasfield-plugin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               ghc-hasfield-plugin
-version:            0.1.0.0
+version:            0.1.1.0
 
 library
   default-language: Haskell2010
@@ -11,12 +11,12 @@ library
   other-modules:
       Data.Record.Plugin.Shim
   build-depends:
-      base             >= 4.13   && < 4.17
-    , containers       >= 0.6.2  && < 0.7
-    , mtl              >= 2.2.1  && < 2.3
+      base >= 4.13
+    , containers
+    , mtl
     , transformers
-    , primitive        >= 0.7    && < 0.8
-    , uniplate 
+    , primitive
+    , uniplate
     , ghc
     , template-haskell
 
@@ -33,8 +33,8 @@ test-suite test
       TestTypes
       Unused
   build-depends:
-      base             >= 4.13   && < 4.17
-    , record-hasfield  >= 1.0    && < 1.1
+      base             >= 4.13
+    , record-hasfield
     , tasty
     , tasty-hunit
     , record-dot-preprocessor

--- a/src/Data/Record/Plugin/Shim.hs
+++ b/src/Data/Record/Plugin/Shim.hs
@@ -38,6 +38,7 @@ module Data.Record.Plugin.Shim (
   , kindedTyVar
   , hsTyVarLName
   , setDefaultSpecificity
+  , mkSrcSpanAnn
 
     -- * Re-exports
 
@@ -58,9 +59,15 @@ module Data.Record.Plugin.Shim (
   , module GHC.Hs
   , module GHC.Plugins
   , module GHC.Tc.Types.Evidence
-  , module GHC.Types.Basic
   , module GHC.Types.Name.Cache
   , module GHC.Utils.Error
+#endif
+#if __GLASGOW_HASKELL__ >= 902
+  , module GHC.Types.SourceText
+  , module GHC.Driver.Errors
+  , module GHC.Utils.Logger
+#else
+  , module GHC.Types.Basic
 #endif
   ) where
 
@@ -91,17 +98,26 @@ import GHC.Core.ConLike (ConLike)
 import GHC.Core.PatSyn (PatSyn)
 import GHC.Data.Bag (listToBag, emptyBag)
 import GHC.Driver.Main (getHscEnv)
-import GHC.Hs hiding (LHsTyVarBndr, HsTyVarBndr, HsModule, mkFunBind)
+import GHC.Hs hiding (LHsTyVarBndr, HsTyVarBndr, HsModule, mkFunBind, AnnType, AnnRec, AnnLet, AnnLam, AnnCase)
 import GHC.Parser.Annotation (IsUnicodeSyntax(NormalSyntax))
 import GHC.Plugins hiding ((<>), getHscEnv, putLogMsg)
 import GHC.Tc.Types.Evidence (HsWrapper(WpHole))
-import GHC.Types.Basic (SourceText(NoSourceText))
 import GHC.Types.Name.Cache (NameCache(nsUniqs))
-import GHC.Utils.Error (Severity(SevError, SevWarning), mkErrMsg, mkWarnMsg)
 
 import qualified GHC.Hs      as GHC
 import qualified GHC.Plugins as GHC
 
+#endif
+
+#if __GLASGOW_HASKELL__ >= 902
+import GHC.Types.SourceText (SourceText(NoSourceText))
+import GHC.Utils.Logger (getLogger)
+import qualified GHC.Utils.Logger as GHC (putLogMsg, Logger, LogAction)
+import GHC.Utils.Error (Severity(SevError, SevWarning), mkErr, mkWarnMsg)
+import GHC.Driver.Errors (printOrThrowWarnings)
+#elif __GLASGOW_HASKELL__ >= 900 && __GLASGOW_HASKELL__ < 902
+import GHC.Types.Basic (SourceText(NoSourceText))
+import GHC.Utils.Error (Severity(SevError, SevWarning), mkErrMsg, mkWarnMsg)
 #endif
 
 {-------------------------------------------------------------------------------
@@ -110,10 +126,18 @@ import qualified GHC.Plugins as GHC
 
 -- | Optionally @qualified@ import declaration
 importDecl :: ModuleName -> Bool -> LImportDecl GhcPs
-importDecl name qualified = noLoc $ ImportDecl {
-      ideclExt       = defExt
+importDecl name qualified = noLocA $ ImportDecl {
+#if __GLASGOW_HASKELL__ < 902
+    ideclExt       = defExt
+#else
+    ideclExt       = noAnn
+#endif
     , ideclSourceSrc = NoSourceText
+#if __GLASGOW_HASKELL__ < 902
     , ideclName      = noLoc name
+#else
+    , ideclName      = noLocA name
+#endif
     , ideclPkgQual   = Nothing
     , ideclSafe      = False
     , ideclImplicit  = False
@@ -131,14 +155,27 @@ importDecl name qualified = noLoc $ ImportDecl {
 #endif
     }
 
+#if __GLASGOW_HASKELL__ < 902
 conPat :: Located RdrName -> HsConPatDetails GhcPs -> Pat GhcPs
+#else
+conPat :: XRec GhcPs (ConLikeP GhcPs) -> HsConPatDetails GhcPs -> Pat GhcPs
+#endif
 #if __GLASGOW_HASKELL__ < 900
 conPat x y = ConPatIn x y
-#else
+#elif __GLASGOW_HASKELL__ >= 900 && __GLASGOW_HASKELL__ < 902
 conPat x y = ConPat noExtField x y
+#else
+conPat x y = ConPat EpAnnNotUsed x y
 #endif
 
+#if __GLASGOW_HASKELL__ < 902
 mkFunBind :: Located RdrName -> [LMatch GhcPs (LHsExpr GhcPs)] -> HsBind GhcPs
+#else
+mkFunBind :: LocatedN RdrName
+          -> [GenLocated
+               SrcSpanAnnA (Match GhcPs (GenLocated SrcSpanAnnA (HsExpr GhcPs)))]
+          -> HsBind GhcPs
+#endif
 #if __GLASGOW_HASKELL__ < 810
 mkFunBind = GHC.mkFunBind
 #else
@@ -154,10 +191,16 @@ type HsModule = GHC.HsModule
 type LHsModule = Located HsModule
 type LRdrName  = Located RdrName
 
+#if __GLASGOW_HASKELL__ < 902
 putLogMsg :: DynFlags -> WarnReason -> Severity -> SrcSpan -> SDoc -> IO ()
+#else
+putLogMsg :: GHC.Logger -> GHC.LogAction
+#endif
 #if __GLASGOW_HASKELL__ < 900
 putLogMsg flags reason sev srcspan =
     GHC.putLogMsg flags reason sev srcspan (defaultErrStyle flags)
+#elif __GLASGOW_HASKELL__ < 902
+putLogMsg = GHC.putLogMsg
 #else
 putLogMsg = GHC.putLogMsg
 #endif
@@ -198,21 +241,36 @@ hsFunTy = HsFunTy
 hsFunTy ext = HsFunTy ext (HsUnrestrictedArrow NormalSyntax)
 #endif
 
+#if __GLASGOW_HASKELL__ < 902
 userTyVar ::
      XUserTyVar pass
   -> Located (IdP pass)
   -> HsTyVarBndr pass
+#else
+userTyVar ::
+  XUserTyVar pass
+  -> XRec pass (IdP pass)
+  -> GHC.HsTyVarBndr () pass
+#endif
 #if __GLASGOW_HASKELL__ < 900
 userTyVar = UserTyVar
 #else
 userTyVar ext = UserTyVar ext ()
 #endif
 
+#if __GLASGOW_HASKELL__ < 902
 kindedTyVar ::
      XKindedTyVar pass
   -> Located (IdP pass)
   -> LHsKind pass
   -> HsTyVarBndr pass
+#else
+kindedTyVar ::
+  XKindedTyVar pass
+  -> LIdP pass
+  -> LHsKind pass
+  -> GHC.HsTyVarBndr () pass
+#endif
 #if __GLASGOW_HASKELL__ < 900
 kindedTyVar = KindedTyVar
 #else
@@ -220,7 +278,11 @@ kindedTyVar ext = KindedTyVar ext ()
 #endif
 
 -- | Like 'hsTyVarName', but don't throw away the location information
+#if __GLASGOW_HASKELL__ < 902
 hsTyVarLName :: HsTyVarBndr GhcPs -> LRdrName
+#else
+hsTyVarLName :: GHC.HsTyVarBndr flag GhcPs -> LIdP GhcPs
+#endif
 #if __GLASGOW_HASKELL__ < 900
 hsTyVarLName (UserTyVar   _ n  ) = n
 hsTyVarLName (KindedTyVar _ n _) = n
@@ -233,17 +295,30 @@ hsTyVarLName (KindedTyVar _ _ n _) = n
 #if __GLASGOW_HASKELL__ < 900
 setDefaultSpecificity :: LHsTyVarBndr pass -> GHC.LHsTyVarBndr pass
 setDefaultSpecificity = id
-#else
+#elif __GLASGOW_HASKELL__  >= 900 && __GLASGOW_HASKELL__ < 902
 setDefaultSpecificity :: LHsTyVarBndr pass -> GHC.LHsTyVarBndr Specificity pass
+setDefaultSpecificity (L l v) = L l $ case v of
+    UserTyVar   ext () name      -> UserTyVar   ext SpecifiedSpec name
+    KindedTyVar ext () name kind -> KindedTyVar ext SpecifiedSpec name kind
+    XTyVarBndr  ext              -> XTyVarBndr  ext
+#elif __GLASGOW_HASKELL__  >= 902
+setDefaultSpecificity :: GenLocated l (GHC.HsTyVarBndr () pass)
+                      -> GenLocated l (GHC.HsTyVarBndr Specificity pass)
 setDefaultSpecificity (L l v) = L l $ case v of
     UserTyVar   ext () name      -> UserTyVar   ext SpecifiedSpec name
     KindedTyVar ext () name kind -> KindedTyVar ext SpecifiedSpec name kind
     XTyVarBndr  ext              -> XTyVarBndr  ext
 #endif
 
+-- New helper function
+mkSrcSpanAnn :: SrcSpan -> SrcSpanAnnA
+mkSrcSpanAnn l = SrcSpanAnn EpAnnNotUsed l
+
 patLoc :: SrcSpan -> Pat (GhcPass id) -> LPat (GhcPass id)
 #if __GLASGOW_HASKELL__ >= 810 && __GLASGOW_HASKELL__ <= 920
-patLoc l p = L l p
+patLoc l p = L l' p
+  where
+    l' = mkSrcSpanAnn l
 #else
 patLoc _ p = p
 #endif
@@ -255,7 +330,7 @@ viewConPat (ConPatIn a b) = Just (a, b)
 viewConPat :: LPat (GhcPass id) -> Maybe (Located (IdP (GhcPass id)), HsConPatDetails (GhcPass id))
 viewConPat (L _ (ConPatIn a b)) = Just (a, b)
 #elif __GLASGOW_HASKELL__ >= 900
-viewConPat :: LPat (GhcPass id) -> Maybe (Located (ConLikeP (GhcPass id)), HsConPatDetails (GhcPass id))
+viewConPat :: LPat (GhcPass id) -> Maybe (XRec (GhcPass id) (ConLikeP (GhcPass id)), HsConPatDetails (GhcPass id))
 viewConPat (L _ (ConPat _ext a b)) = Just (a, b)
 #endif
 viewConPat _ = Nothing


### PR DESCRIPTION
This is a PR  _on a best-effort basis_ to upgrade `ghc-hasfield-plugin` to build and work with GHC 9.2.8 and it's updated package-set.

This was done as part of the larger effort to bring Euler to GHC 9.2.x ecosystem.

This package hasn't been touched or updated in a while and no one seems to actively maintain it, therefore it had a lot of breakages to fix when getting it ready to build and work with GHC 9.2.8 owing to the ghc api changes between 8.10.x -> 9.2.x

## Main changes
- The `Shims.hs` file is the file with conditional code, that compiles differently with different GHC compiler versions, relevant changes were made to fix the breakages and make it compatible with new ghc 9.2.8 API.
- The main plugin `HasFieldPattern.hs` file, gets updated fair and square to GHC 9.2.x, this again contains relevant changes to make this compile and build with GHC 9.2.x and make it compatible and conform to the newer ghc API
- Remove version bounds on dependency from project's cabal file. The versions should come from the stack or Nix package-set of the project that uses this plugin.
- Bump package version to `0.1.0.0` -> `0.1.1.0`

### How was this tested?
- The project builds now with GHC 9.2.8, where it didn't before.
- The test-suite of the project passes, like it did before it was upgraded.
- The project that uses this plugin downstream seems to work fine, like it did before, intimating correct or similar behaviour as before.

### Result
The project builds and tests fine after being updated to GHC 9.2.8 and it's updated package set.